### PR TITLE
Allow specifying a private_key in DATABASES 'OPTIONS' without PASSWORD or authenticator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2 beta 2 - Unreleased
+
+* Allowed specifying a `private_key` in the `'OPTIONS'` dictionary in the
+  `DATABASES` setting without also specifying `PASSWORD` or `authenticator`.
+
 ## 4.2 beta 1 - 2023-04-11
 
 * Added support for `JSONField`.

--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -111,7 +111,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         if settings_dict['PASSWORD']:
             conn_params['password'] = settings_dict['PASSWORD']
-        elif 'authenticator' not in conn_params:
+        elif 'private_key' not in conn_params and 'authenticator' not in conn_params:
             raise ImproperlyConfigured(self.settings_is_missing % 'PASSWORD')
 
         if settings_dict.get('ACCOUNT'):


### PR DESCRIPTION
Current implementation requires an explicit
`authenticator = 'SNOWFLAKE_JWT'` value to be passed when supplying a `private_key` config.

Conventionally [it should be adequate](https://github.com/snowflakedb/snowflake-connector-python/blob/0894b7886793d92533c778d5becbd2f529418cc1/src/snowflake/connector/connection.py#L958-L959) to supply only a `private_key` and have it ignore `PASSWORD` without also requiring `authenticator`.

This change makes passing `authenticator` optional when passing a `private_key` value.

Manually tested with configs:

```python
# Passes (Only private_key, no password)
DATABASES = {
    'default': {
        'ENGINE': 'django_snowflake',
        …
        'OPTIONS': {
            'private_key': pkb,
        },
    },
}
```

```python
# Passes (Only authenticator, no password)
DATABASES = {
    'default': {
        'ENGINE': 'django_snowflake',
        …
        'OPTIONS': {
            'authenticator': 'externalbrowser',
        },
    },
}
```

```python
# Passes (both options, no password)
DATABASES = {
    'default': {
        'ENGINE': 'django_snowflake',
        …
        'OPTIONS': {
            'private_key': pkb,
            'authenticator': 'SNOWFLAKE_JWT',
        },
    },
}
```

```python
# Fails (no options, no password)
DATABASES = {
    'default': {
        'ENGINE': 'django_snowflake',
        …
        'OPTIONS': {},
    },
}
```

All invalid values continue to fail with appropriate exceptions.
Specifying password while specifying the other options defers to the priority order in the connector.