### PR TITLE
Fix private key authentication with dbshell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## 4.2 beta 2 - Unreleased
 
-* Allowed specifying a `private_key` in the `'OPTIONS'` dictionary in the
-  `DATABASES` setting without also specifying `PASSWORD` or `authenticator`.
+* Bumped the minimum required version of `snowflake-connector-python` to 3.6.0.
+
+* Fixed private key authentication with `dbshell`. For this to work, you must
+  use `'private_key_file'` and`'private_key_file_pwd'` in the `'OPTIONS'`
+  dictionary of the `DATABASES` setting instead of `'private_key'`. This is
+  now the documented pattern in the README.
 
 ## 4.2 beta 1 - 2023-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   dictionary of the `DATABASES` setting instead of `'private_key'`. This is
   now the documented pattern in the README.
 
+* Fixed `dbshell` crash if using the `client_session_keep_alive` or
+  `passcode_in_password` options.
+
 ## 4.2 beta 1 - 2023-04-11
 
 * Added support for `JSONField`.

--- a/README.md
+++ b/README.md
@@ -48,10 +48,9 @@ DATABASES = {
             # To use native Okta authenticators:
             # https://docs.snowflake.com/en/user-guide/admin-security-fed-auth-use#native-sso-okta-only
             'authenticator': 'https://example.okta.com',
-            # To use private key authentication, obtaining the pkb variable
-            # using the sample code at:
-            # https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#label-python-key-pair-authn-rotation
-            'private_key': pkb,
+            # To use private key authentication:
+            'private_key_file': '<path>/rsa_key.p8',
+            'private_key_file_pwd': 'my_passphrase',
         },
     },
 }

--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -90,6 +90,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     introspection_class = DatabaseIntrospection
     ops_class = DatabaseOperations
 
+    password_not_required_options = ('private_key', 'private_key_file', 'authenticator')
     settings_is_missing = "settings.DATABASES is missing '%s' for 'django_snowflake'."
 
     def get_connection_params(self):
@@ -111,7 +112,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         if settings_dict['PASSWORD']:
             conn_params['password'] = settings_dict['PASSWORD']
-        elif 'private_key' not in conn_params and 'authenticator' not in conn_params:
+        elif all(x not in conn_params for x in self.password_not_required_options):
             raise ImproperlyConfigured(self.settings_is_missing % 'PASSWORD')
 
         if settings_dict.get('ACCOUNT'):

--- a/django_snowflake/client.py
+++ b/django_snowflake/client.py
@@ -34,7 +34,7 @@ class DatabaseClient(BaseDatabaseClient):
         if authenticator:
             args += ['--authenticator', authenticator]
         if client_session_keep_alive:
-            args += ['--client-session-keep-alive', client_session_keep_alive]
+            args += ['--client-session-keep-alive']
         if dbname:
             args += ['-d', dbname]
         if host:
@@ -42,7 +42,7 @@ class DatabaseClient(BaseDatabaseClient):
         if passcode:
             args += ['--mfa-passcode', passcode]
         if passcode_in_password:
-            args += ['--mfa-passcode-in-password', passcode_in_password]
+            args += ['--mfa-passcode-in-password']
         if private_key_file:
             args += ['--private-key-path', private_key_file]
         if role:

--- a/django_snowflake/client.py
+++ b/django_snowflake/client.py
@@ -24,7 +24,8 @@ class DatabaseClient(BaseDatabaseClient):
         client_session_keep_alive = options.get('client_session_keep_alive')
         passcode = options.get('passcode')
         passcode_in_password = options.get('passcode_in_password')
-        private_key = options.get('private_key')
+        private_key_file = options.get('private_key_file')
+        private_key_file_pwd = options.get('private_key_file_pwd')
         role = options.get('role')
         token = options.get('token')
 
@@ -42,8 +43,8 @@ class DatabaseClient(BaseDatabaseClient):
             args += ['--mfa-passcode', passcode]
         if passcode_in_password:
             args += ['--mfa-passcode-in-password', passcode_in_password]
-        if private_key:
-            args += ['--private-key-path', private_key]
+        if private_key_file:
+            args += ['--private-key-path', private_key_file]
         if role:
             args += ['-r', role]
         if schema:
@@ -58,6 +59,8 @@ class DatabaseClient(BaseDatabaseClient):
         env = {}
         if password:
             env['SNOWSQL_PWD'] = password
+        if private_key_file_pwd:
+            env['SNOWSQL_PRIVATE_KEY_PASSPHRASE'] = private_key_file_pwd
         return args, (env or None)
 
     def runshell(self, parameters):

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ project_urls =
 python_requires = >=3.8
 packages = find:
 install_requires =
-    snowflake-connector-python >= 2.7.4
+    snowflake-connector-python >= 3.6.0
 
 [flake8]
 max-line-length = 119


### PR DESCRIPTION
Fixes #67 

(Pending the release of snowflake-connector-python 3.6.0 which supports the new options.)