### PR TITLE
Fix crash in DatabaseIntrospection.get_table_description() due to Snowflake's DESCRIBE TABLE change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.1 - Unreleased
+
+* Fixed crash in `DatabaseIntrospection.get_table_description()` due to
+  Snowflake adding a column to the output of `DESCRIBE TABLE` in behavior
+  change bundle 2023_08.
+
 ## 5.0 - 2023-12-16
 
 Initial release for Django 5.0.x.

--- a/django_snowflake/introspection.py
+++ b/django_snowflake/introspection.py
@@ -166,7 +166,9 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             )
             for (
                 name, data_type, kind, null, default, pk, unique_key, check,
-                expression, comment, policy_name,
+                # *_ ignores policy_name, privacy_domain, and any future
+                # columns in DESCRIBE TABLE output.
+                expression, comment, *_
             ) in table_info
         ]
 


### PR DESCRIPTION
The "privacy domain" column is new in behavior change bundle 2023_08.