### PR TITLE
Fix data corruption of new model instance IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.0.2 - Unreleased
+
+* Fixed data corruption of new model instance IDs. Connection initialization
+  now sets `NOORDER_SEQUENCE_AS_DEFAULT=False` (after [the default
+  changed to True](https://docs.snowflake.com/en/release-notes/bcr-bundles/2024_01/bcr-1483)
+  in behavior change bundle 2024_01) to allow this backend to continue to
+  retrieve the ID of newly created objects using
+  `SELECT MAX(pk_name) FROM table_name`.
+
 ## 5.0.1 - 2024-02-07
 
 * Fixed crash in `DatabaseIntrospection.get_table_description()` due to

--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -149,6 +149,10 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return False
 
     def init_connection_state(self):
+        # AUTOINCREMENT IDs must be monotonically increasing in order for
+        # DatabaseOperations.last_insert_id() to fetch the correct ID.
+        with self.connection.cursor() as cursor:
+            cursor.execute("ALTER SESSION SET NOORDER_SEQUENCE_AS_DEFAULT=False")
         timezone_changed = self.ensure_timezone()
         if timezone_changed:
             # Commit after setting the time zone (see #17062)


### PR DESCRIPTION
The behavior of AUTOINCREMENT ids changed in behavior change bundle 2024_01.