### PR TITLE
Changede UUIDField data type to translate to VARCHAR(36)

### DIFF
--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -49,7 +49,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         'SmallIntegerField': 'NUMBER(5,0)',
         'TextField': 'VARCHAR',
         'TimeField': 'TIME',
-        'UUIDField': 'VARCHAR(32)',
+        'UUIDField': 'VARCHAR(36)',
     }
     data_types_suffix = {
         'AutoField': 'AUTOINCREMENT',


### PR DESCRIPTION
Hi,

I was playing with django-snowflake library and tried to connect one of my other projects to Snowflake.
On that project our models PKs are mainly UUIDs, so when I ran the migration I got an error saying that
UUID string is too long for a VARCHAR(32) field and I started looking into the Snowflake documentation
and saw that Snowflake actually usses VARCHAR(36) for UUID fields (here is also a link to the docs: https://docs.snowflake.com/en/sql-reference/functions/uuid_string). Once I changed that in my library it fixed the problem.

